### PR TITLE
Ensure that the 'href' of each item in the 'Course Sections' nav menu…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -312,7 +312,8 @@ function theme_moove_rebuildcoursesections(\flat_navigation $flatnav) {
                     'icon' => $item->icon,
                     'type' => $item->type,
                     'key' => $item->key,
-                    'parent' => $coursesections
+                    'parent' => $coursesections,
+                    'action' => $item->action
                 ]));
             }
         }


### PR DESCRIPTION
… is populated with '/course/view.php?id=xx&section=yy' so that each course section item navigates into the correct section when clicked, if the course is set to display one topic at a time (at present href is blank for each item)