### PR TITLE
Update slideshow.mustache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 [![Build Status](https://travis-ci.org/willianmano/moodle-theme_moove.svg?branch=master)](https://travis-ci.org/willianmano/moodle-theme_moove)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/e1c12730e50b4e479dc9a65dbeff6671)](https://www.codacy.com/app/willianmanoaraujo/moodle-theme_moove?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=willianmano/moodle-theme_moove&amp;utm_campaign=Badge_Grade)
 
+Differences:
+===============================
+
+In slideshow.mustache:
+
+Removed alt tag until address the problem with caption text containing html tags (without strip_tags).
+Removed bootstrap .d-none and .d-md-block attributes as the text blocks should displayed always no matter what is the display resolution.
+Added javascript function to force start slideshow as it isnt started in our Moodle instances despite the fdix mentioned in the latest release.
+
 
 Moodle "Moove" theme repository
 ===============================

--- a/templates/slideshow.mustache
+++ b/templates/slideshow.mustache
@@ -42,9 +42,9 @@
         <div class="carousel-inner">
             {{#slides}}
                 <div class="carousel-item {{#active}}active{{/active}}">
-                    <img class="d-block w-100 animated fadeIn" src="{{{ image }}}" alt="{{{ caption }}}">
+                    <img class="d-block w-100 animated fadeIn" src="{{{ image }}}" alt="{{{ }}}">
 
-                    <div class="carousel-caption d-none d-md-block animated fadeInRightBig">
+                    <div class="carousel-caption animated fadeInRightBig">
                         {{#title}}<h2 class="title">{{{ title }}}</h2>{{/title}}
 
                         {{#caption}}<div class="caption">{{{ caption }}}</div>{{/caption}}
@@ -53,4 +53,11 @@
             {{/slides}}
         </div>
     </div>
+{{#js}}
+require(['jquery','bootstrap'], function() {
+	$('#mooveslideshow').carousel({
+	  interval: 5000
+	})
+})
+{{/js}}	
 {{/sliderenabled}}


### PR DESCRIPTION
Removed alt tag until address the problem with caption text containing html tags (without strip_tags).
Removed bootstrap .d-none and .d-md-block attributes as the text blocks should displayed always no matter what is the display resolution.
Added javascript function to force start slideshow as it isnt started in our Moodle instances despite the fdix mentioned in the latest release.