### PR TITLE
Make slideshow and clients title and caption fields as translatable

### DIFF
--- a/classes/util/theme_settings.php
+++ b/classes/util/theme_settings.php
@@ -205,8 +205,9 @@ class theme_settings {
     public function clients() {
         $theme = theme_config::load('moove');
 
-        $templatecontext['clientstitle'] = $theme->settings->clientstitle;
-        $templatecontext['clientssubtitle'] = $theme->settings->clientssubtitle;
+        $templatecontext['clientstitle'] = format_string($theme->settings->clientstitle);
+        $templatecontext['clientssubtitle'] = format_string($theme->settings->clientssubtitle);
+
 
         $clientscount = $theme->settings->clientscount;
 

--- a/classes/util/theme_settings.php
+++ b/classes/util/theme_settings.php
@@ -94,7 +94,7 @@ class theme_settings {
             }
             $templatecontext['slides'][$j]['image'] = $image;
             $templatecontext['slides'][$j]['title'] = format_string($theme->settings->$slidertitle);
-            $templatecontext['slides'][$j]['caption'] = format_string($theme->settings->$slidercap);
+            $templatecontext['slides'][$j]['caption'] = format_text($theme->settings->$slidercap);
 
             if ($i === 1) {
                 $templatecontext['slides'][$j]['active'] = true;


### PR DESCRIPTION
From Banner rotativo #243
These 4 fields should be filtered as strings or text to let them be translatable by Moodle translation plugins