### PR TITLE
Enabled HTML in custom menu text

### DIFF
--- a/templates/core/custom_menu_item.mustache
+++ b/templates/core/custom_menu_item.mustache
@@ -25,7 +25,7 @@
 {{#haschildren}}
 <div class="dropdown nav-item">
     <a class="dropdown-toggle nav-link" id="drop-down-{{uniqid}}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#">
-        {{text}}
+        {{{text}}}
     </a>
     <div class="dropdown-menu" aria-labelledby="drop-down-{{uniqid}}">
         {{#children}}
@@ -40,6 +40,6 @@
 </div>
 {{/haschildren}}
 {{^haschildren}}
-<li class="nav-item"><a class="nav-link" href="{{{url}}}" {{#title}}title="{{{title}}}"{{/title}}>{{text}}</a></li>
+<li class="nav-item"><a class="nav-link" href="{{{url}}}" {{#title}}title="{{{title}}}"{{/title}}>{{{text}}}</a></li>
 {{/haschildren}}
 {{/divider}}


### PR DESCRIPTION
This is important if site administrators want to add things like Font Awesome icons, or ABBR tags for acronyms to menu items.

Side note: There have been some important changes to this file, which has deviated from the core template, leaving room for improvement with regards to compliance with WCAG 2.1. Please consider reviewing and updating it.

Let me know if you have any questions or concerns.

Best regards,

Michael Milette