### PR TITLE
Add grey background to hidden elements

### DIFF
--- a/scss/moove/_breadcrumb.scss
+++ b/scss/moove/_breadcrumb.scss
@@ -34,6 +34,14 @@
                 border-color: #f7f7f7;
             }
         }
+
+        .breadcrumb-item.dimmed_text_fhs a {
+            background-color: #c5c8cc;
+        }
+    }
+    
+    .breadcrumb li.dimmed_text_fhs > * {
+        border-color: #c5c8cc;
     }
     .breadcrumb li:last-of-type::after {
         display: none;

--- a/scss/moove/_course.scss
+++ b/scss/moove/_course.scss
@@ -90,6 +90,10 @@ body.coursepresentation-cover {
                     margin-left: 12px;
                 }
             }
+
+            .section.hidden {
+                background-color: #dee2e6;
+            }
         }
 
         .single-section .sectionname,

--- a/templates/core/navbar.mustache
+++ b/templates/core/navbar.mustache
@@ -62,10 +62,10 @@
     <ol class="breadcrumb">
         {{#get_items}}
             {{#has_action}}
-                <li class="breadcrumb-item"><a href="{{{action}}}" {{#get_title}}title="{{get_title}}"{{/get_title}}>{{{text}}}</a></li>
+                <li class="breadcrumb-item {{#is_hidden}}dimmed_text_fhs{{/is_hidden}}"><a href="{{{action}}}" {{#get_title}}title="{{get_title}}"{{/get_title}}>{{{text}}}</a></li>
             {{/has_action}}
             {{^has_action}}
-                <li class="breadcrumb-item"><span class="no-link">{{{text}}}</span></li>
+                <li class="breadcrumb-item {{#is_hidden}}dimmed_text_fhs{{/is_hidden}}"><span class="no-link">{{{text}}}</span></li>
             {{/has_action}}
         {{/get_items}}
     </ol>


### PR DESCRIPTION
This commit adds a grey background colour to this elements when those are hidden:
- Breadcrumb elements (category, course, section, activity...)
- Section background on course page