### PR TITLE
Fix profile page loading when userid parameter is missing

### DIFF
--- a/layout/mypublic.php
+++ b/layout/mypublic.php
@@ -29,6 +29,7 @@ global $DB, $USER, $OUTPUT, $SITE, $PAGE;
 // Get the profile userid.
 $courseid = optional_param('course', 1, PARAM_INT);
 $userid = optional_param('id', $USER->id, PARAM_INT);
+$userid = $userid ? $userid : $USER->id;
 $user = $DB->get_record('user', ['id' => $userid], '*', MUST_EXIST);
 
 $primary = new core\navigation\output\primary($PAGE);


### PR DESCRIPTION
This will fix the issue https://github.com/willianmano/moodle-theme_moove/issues/382 as well as any profile page loading when the userid parameter is missing or is equal to 0.

Another example where you can reproduce this bug is when a user is looking at his/her profile page and wants to change the language through the user menu. After clicking on any language it will redirect to an URL where the userid is equal to 0 (E.g. https://[somedomain]/moodle400/user/profile.php?**id=0**&lang=es).

This error happens because the call to the function get_record() in this line https://github.com/willianmano/moodle-theme_moove/blob/aa2b9f0acf36bd47d5dc802935819b765ea39cf3/layout/mypublic.php#L32 will throw a Moodle exception after  trying to get a record where a userid is equal to 0, but there is none.

You can take a look exactly to where this Moodle exception happens as the function is called with the parameter MUST_EXIST here:
https://github.com/moodle/moodle/blob/bcd0bdaf513fc76213c04bd581f6afd430b32fb4/lib/dml/moodle_database.php#L1673