### PR TITLE
Fixes 474 - Support for Password visibility toggle

### DIFF
--- a/templates/core/loginform.mustache
+++ b/templates/core/loginform.mustache
@@ -246,4 +246,9 @@
     {{#error}}
         document.getElementById('loginerrormessage').focus();
     {{/error}}
+    {{#togglepassword}}
+        require(['core/togglesensitive'], function(ToggleSensitive) {
+            ToggleSensitive.init("password", {{smallscreensonly}});
+        });
+    {{/togglepassword}}
 {{/js}}


### PR DESCRIPTION
Support 'Password visibility toggle' (loginpasswordtoggle) feature added in Moodle 4.4 by MDL-79769.

Proposed fix for #474.