### PR TITLE
Add custom css settings for mod_hvp plugin

### DIFF
--- a/classes/mod_hvp_renderer.php
+++ b/classes/mod_hvp_renderer.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die;
+
+global $CFG;
+$h5prenderer = $CFG->dirroot.'/mod/hvp/renderer.php';
+if (file_exists($h5prenderer)) {
+    // Be sure to include the H5P renderer so it can be extended.
+    require_once($h5prenderer);
+
+    /**
+     * Class theme_moove_mod_hvp_renderer
+     */
+    class theme_moove_mod_hvp_renderer extends mod_hvp_renderer {
+        public function hvp_alter_styles(&$styles, $libraries, $embedtype) {
+            global $CFG;
+            $theme = theme_config::load('moove');
+            $h5pcss = $theme->setting_file_url('h5pcss', 'h5pcss');
+            if (empty($h5pcss)) {
+                return;
+            }
+
+            // Convert url as h5p expects full https at start instead of "//" returned by setting_file_url.
+            $relativebaseurl = preg_replace('|^https?://|i', '//', $CFG->wwwroot);
+            $h5pcss = str_replace($relativebaseurl, '', $h5pcss);
+
+            $styles[] = (object) array(
+                'path' => new \moodle_url($h5pcss),
+                'version' => '?ver=0.0.1',
+            );
+        }
+    }
+}

--- a/lang/en/theme_moove.php
+++ b/lang/en/theme_moove.php
@@ -72,6 +72,8 @@ $string['rawscss'] = 'Raw SCSS';
 $string['rawscss_desc'] = 'Use this field to provide SCSS or CSS code which will be injected at the end of the style sheet.';
 $string['googleanalytics'] = 'Google Analytics V4 Code';
 $string['googleanalyticsdesc'] = 'Please enter your Google Analytics V4 code to enable analytics on your website. The code format shold be like [G-XXXXXXXXXX]';
+$string['h5pcss'] = 'Raw H5P CSS';
+$string['h5pcss_desc'] = 'Use this field to provide a CSS file which will be injected on mod_hvp plugin pages.';
 
 // Frontpage settings tab.
 $string['frontpagesettings'] = 'Frontpage';

--- a/lib.php
+++ b/lib.php
@@ -185,5 +185,9 @@ function theme_moove_pluginfile($course, $cm, $context, $filearea, $args, $force
         return $theme->setting_file_serve('marketing4icon', $args, $forcedownload, $options);
     }
 
+    if ($context->contextlevel == CONTEXT_SYSTEM && $filearea === 'h5pcss') {
+        return $theme->setting_file_serve('h5pcss', $args, $forcedownload, $options);
+    }
+
     send_file_not_found();
 }

--- a/settings.php
+++ b/settings.php
@@ -176,6 +176,13 @@ if ($ADMIN->fulltree) {
     $setting->set_updatedcallback('theme_reset_all_caches');
     $page->add($setting);
 
+    // Raw H5P SCSS to include after the content.
+    $title = get_string('h5pcss', 'theme_moove');
+    $description = get_string('h5pcss_desc', 'theme_moove');
+    $setting = new admin_setting_configstoredfile('theme_moove/h5pcss', $title, $description, 'h5pcss', 0,
+        array('maxfiles' => 1, 'accepted_types' => array('.css')));
+    $page->add($setting);
+
     $settings->add($page);
 
     /*


### PR DESCRIPTION
Hi @willianmano - here's a patch we've created on one of our local sites using Moove that allows the admin to drop in a css file that applies to hvp content on the page (support for mod_hvp) - just dropping it here in case it's useful - you may want to drop in some code to only show the settings when mod_hvp is installed and may have other improvements you want to make.

Feel free to close it as won't fix though!