### PR TITLE
Issue #485: Added check for before evaluating strpos

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -203,7 +203,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
             foreach ($context->identityproviders as $key => $provider) {
                 $isfacebook = false;
 
-                if (strpos($provider['iconurl'], 'facebook') !== false) {
+                if (!empty($provider['iconurl']) && strpos($provider['iconurl'], 'facebook') !== false) {
                     $isfacebook = true;
                 }
 


### PR DESCRIPTION
Closes #485.

Added a check to see if `$provider['iconurl']` is null before evaluating `strpos()`.