### PR TITLE
Issue #495: Added require_once to fix unit test error

### DIFF
--- a/classes/output/core/admin_renderer.php
+++ b/classes/output/core/admin_renderer.php
@@ -29,6 +29,7 @@ use core\context\course as context_course;
 use moodle_url;
 use html_writer;
 use theme_moove\output\core_course\activity_navigation;
+require_once($CFG->dirroot . '/admin/renderer.php');
 
 /**
  * Standard HTML output renderer for core_admin subsystem.


### PR DESCRIPTION
Closes Issue #495. 

Adding `require_once($CFG->dirroot . '/admin/renderer.php');` fixes the PHP unit test error appearing. 

**Testing Instructions**
1. Deploy Moodle 4.5 instance with `theme_moove` installed
2. Initialize PHP Unit testing environment
3. Run `lib/tests/component_test.php`
4. See the error
5. Add the fix from `catalyst-main`
6. Re-run test and see successful test output
```
Moodle 4.5.2+ (Build: 20250314), feca93ca774d9ee5e05bd5d8362b610311359361
Php: 8.1.28, mysqli: 8.0.37, OS: Linux 6.8.0-57-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

...............................................................  63 / 168 ( 37%)
............................................................... 126 / 168 ( 75%)
..........................................                      168 / 168 (100%)

Time: 01:12.068, Memory: 103.00 MB

OK (168 tests, 7019 assertions)
```